### PR TITLE
fix:eventlogの保存先の変更(サブコレクションに変更)

### DIFF
--- a/backend/modules/event/event.py
+++ b/backend/modules/event/event.py
@@ -77,13 +77,11 @@ class Event:
         """
 
         data = {
-            "room_id": self.room_id,
-            "event_name": "テストイベント",
-            "event_output": "",
+            "date": datetime.now().isoformat(),
+            "text": "テストイベント"
         }
-        event_logs_ref = self.db.collection("event_logs")
-        doc_ref = event_logs_ref.document(self.room_id)
-        doc_ref.update(data)
+        event_logs_ref = self.db.collection("event_logs").document(self.room_id).collection("logs").document()
+        event_logs_ref.set(data)
 
     def check_db(self) -> bool:
         """


### PR DESCRIPTION
今までevent_logの保存先が、
event_logs/{document}/
に、
{
"event_name" : string,
 "event_output" : string,
 "room_id" : string
}
としてフィールドを保存していたのを、
event_logd/{roomDocumentId}/logs
に
{
"date" : TimeStamp
"test" : string
}
というフィールドを持つドキュメントをサブコレクションの中に作るようにしました。